### PR TITLE
Actualiza columna sexo s

### DIFF
--- a/app/assets/javascripts/sivel2_sjr/motor.js.coffee
+++ b/app/assets/javascripts/sivel2_sjr/motor.js.coffee
@@ -168,10 +168,14 @@
     fr = +$(pref + '_fr').val()
     $(pref + '_fr').val(fr + (+cantidad))
     cor1440_gen_rangoedadac($(pref + '_fr'))
-  else    
+  else if sexo == 'M'    
     mr = +$(pref + '_mr').val()
     $(pref + '_mr').val(mr + (+cantidad))
     cor1440_gen_rangoedadac($(pref + '_mr'))
+  else    
+    sr = +$(pref + '_s').val()
+    $(pref + '_s').val(sr + (+cantidad))
+    cor1440_gen_rangoedadac($(pref + '_s'))
 
 # Recalcula tabla poblacion en actividad a partir de listado de 
 # personas beneficiarias  y de casos beneficiarios
@@ -189,11 +193,19 @@
       $(this).val(0)
       $(this).prop('readonly', true);
     ) 
+    $('input[id^=actividad_actividad_rangoedadac_attributes_][id$=_s]').each((i, v) ->
+      $(this).val(0)
+      $(this).prop('readonly', true);
+    ) 
   else
     $('input[id^=actividad_actividad_rangoedadac_attributes_][id$=_fr]').each((i, v) ->
       $(this).prop('readonly', false);
     )
     $('input[id^=actividad_actividad_rangoedadac_attributes_][id$=_mr]').each((i, v) ->
+      $(this).val(0)
+      $(this).prop('readonly', false);
+    ) 
+    $('input[id^=actividad_actividad_rangoedadac_attributes_][id$=_s]').each((i, v) ->
       $(this).val(0)
       $(this).prop('readonly', false);
     ) 

--- a/app/views/cor1440_gen/actividades/_actividad_rangoedadac_fields.html.erb
+++ b/app/views/cor1440_gen/actividades/_actividad_rangoedadac_fields.html.erb
@@ -17,6 +17,9 @@
     <%= f.number_field :mr, size: "2", readonly: desr %>
   </td>
   <td>
+    <%= f.number_field :s, size: "2", readonly: desr %>
+  </td>
+  <td>
     <%= 
       f.input :id, as: :hidden %><%= link_to_remove_association "Eliminar", f, 
         :class => 'btn-danger' 

--- a/test/dummy/db/structure.sql
+++ b/test/dummy/db/structure.sql
@@ -684,7 +684,8 @@ CREATE TABLE public.cor1440_gen_actividad_rangoedadac (
     fl integer,
     fr integer,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    s integer
 );
 
 
@@ -9658,6 +9659,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191205202150'),
 ('20191205204511'),
 ('20191219011910'),
-('20191231102721');
+('20191231102721'),
+('20200116003807');
 
 


### PR DESCRIPTION
R-976 En formulario de actividad en la tabla población agregar una columna "Externos otro sexo o desconocido" (agregar en base, modelo, controlador, vista, en base emplear 'S' en lugar de 'F' o 'M') . En listado de asistencia agregar opción 'S' para sexo de una persona. En vista (javascript): (1) modificar cálculo de totales de esa tabla para incluir esa columna, (2) modificar el llenado automático de esa tabla cuando se llena listado de asistencia (beneficiarios) o de casos, para que cuando se agregen personas con sexo 'S' (bien porque están en listado de asistencia o bien porque están en caso beneficiario) se incremente la columna 'S' y no 'M' como se hace actualmente. 